### PR TITLE
`PP$` is actually `PRP$` (and corrected `Ós` to `'s` and `oneÓs` to `one's`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ TAGS:
     NNP Proper noun, sing.      Edinburgh
     NNPS Proper noun, plural    Smiths
     NNS Noun, plural            dogs
-    POS Possessive ending       ’s
+    POS Possessive ending       's
     PDT Predeterminer           all, both
-    PP$ Possessive pronoun      my,one’s
-    PRP Personal pronoun         I,you,she
+    PRP$ Possessive pronoun     my,one's
+    PRP Personal pronoun        I,you,she
     RB Adverb                   quickly
     RBR Adverb, comparative     faster
     RBS Adverb, superlative     fastest
     RP Particle                 up,off
     SYM Symbol                  +,%,&
-    TO “to”                     to
+    TO √íto√ì                     to
     UH Interjection             oh, oops
     VB verb, base form          eat
     VBD verb, past tense        ate
@@ -83,7 +83,7 @@ TAGS:
     WRB Wh-adverb               how,where
     , Comma                     ,
     . Sent-final punct          . ! ?
-    : Mid-sent punct.           : ; —
+    : Mid-sent punct.           : ; √ë
     $ Dollar sign               $
     # Pound sign                #
     " quote                     "

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ TAGS:
     RBS Adverb, superlative     fastest
     RP Particle                 up,off
     SYM Symbol                  +,%,&
-    TO ÒtoÓ                     to
+    TO 'to'                     to
     UH Interjection             oh, oops
     VB verb, base form          eat
     VBD verb, past tense        ate


### PR DESCRIPTION
I was wondering why words like "your", "their", "my" weren't understood by an application I'm writing. Apparently the library returns `PRP$` instead of `PP$`. The length of most tags are 1-3 characters long. The `PRP$` tag being the only one having 4 characters suggest this might be a bug in the library instead, and not the documentation. But for now, until someone decides the library should change, let at least have the documentation reflect the actual tag used by the library.